### PR TITLE
修改了插件的加载方式:

### DIFF
--- a/Code/['World']['Global']['Framework']['Client']['ClientModule'].ModuleScript.lua
+++ b/Code/['World']['Global']['Framework']['Client']['ClientModule'].ModuleScript.lua
@@ -70,9 +70,11 @@ function InitClientCustomEvents()
     end
 
     -- 将插件中的CustomEvent放入Events.ClientEvents中
-    for _, m in pairs(Config.PluginEvents) do
-        local evts = _G[m].ClientEvents
-        assert(evts, string.format('[Client] %s 中不存在ClientEvents，请检查模块，或从FrameworkConfig删除此配置', m))
+    for _, m in pairs(PluginConfig) do
+        if not _G[m].Events then
+            return
+        end
+        local evts = _G[m].Events.ServerEvents
         for __, evt in pairs(evts) do
             if not table.exists(Events.ClientEvents, evt) then
                 table.insert(Events.ClientEvents, evt)
@@ -108,14 +110,17 @@ function GenInitAndUpdateList()
     -- FixedUpdate
     ModuleUtil.GetModuleListWithFunc(Module.C_Module, 'FixedUpdate', fixedUpdateList)
     -- Plugin
-    for _, m in pairs(Config.PluginModules) do
-        ModuleUtil.GetModuleListWithFunc(m, 'InitDefault', initDefaultList)
-        ModuleUtil.GetModuleListWithFunc(m, 'Awake', awakeList)
-        ModuleUtil.GetModuleListWithFunc(m, 'Start', startList)
-        ModuleUtil.GetModuleListWithFunc(m, 'OnPreRender', onPreRenderList)
-        ModuleUtil.GetModuleListWithFunc(m, 'Update', updateList)
-        ModuleUtil.GetModuleListWithFunc(m, 'LateUpdate', lateUpdateList)
-        ModuleUtil.GetModuleListWithFunc(m, 'FixedUpdate', fixedUpdateList)
+    for _, m in pairs(PluginConfig) do
+        if not Plugin[m].C_Module then
+            return
+        end
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].C_Module, 'InitDefault', initDefaultList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].C_Module, 'Awake', awakeList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].C_Module, 'Start', startList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].C_Module, 'OnPreRender', onPreRenderList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].C_Module, 'Update', updateList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].C_Module, 'LateUpdate', lateUpdateList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].C_Module, 'FixedUpdate', fixedUpdateList)
     end
 end
 

--- a/Code/['World']['Global']['Framework']['FrameworkConfigModule'].ModuleScript.lua
+++ b/Code/['World']['Global']['Framework']['FrameworkConfigModule'].ModuleScript.lua
@@ -21,10 +21,6 @@ local FrameworkConfig = {
         -- threshold_2 -> longer        : disconnected, remove player
         HeartbeatThreshold1 = 5,
         HeartbeatThreshold2 = 10,
-        -- 插件中需要使用声明周期的服务器模块目录
-        PluginModules = {},
-        -- 插件中服务器需要生成的CustomEvent, 模块中必须得有ServerEvents
-        PluginEvents = {}
     },
     -- 客户端配置
     Client = {
@@ -36,10 +32,6 @@ local FrameworkConfig = {
         -- threshold_2 -> longer        : disconnected, quit server
         HeartbeatThreshold1 = 5,
         HeartbeatThreshold2 = 10,
-        -- 插件中需要使用声明周期的客户端模块目录
-        PluginModules = {},
-        -- 插件中客户端需要生成的CustomEvent，模块中必须得有ClientEvents
-        PluginEvents = {}
     },
     --! Debug相关
     Debug = {

--- a/Code/['World']['Global']['Framework']['Server']['ServerModule'].ModuleScript.lua
+++ b/Code/['World']['Global']['Framework']['Server']['ServerModule'].ModuleScript.lua
@@ -54,9 +54,11 @@ function InitServerCustomEvents()
     end
 
     -- 将插件中的CustomEvent放入Events.ClientEvents中
-    for _, m in pairs(Config.PluginEvents) do
-        local evts = _G[m].ServerEvents
-        assert(evts, string.format('[Server] %s 中不存在ServerEvents，请检查模块，或从FrameworkConfig删除此配置', m))
+    for _, m in pairs(PluginConfig) do
+        if not _G[m].Events then
+            return
+        end
+        local evts = _G[m].Events.ServerEvents
         for __, evt in pairs(evts) do
             if not table.exists(Events.ServerEvents, evt) then
                 table.insert(Events.ServerEvents, evt)
@@ -112,13 +114,16 @@ function GenInitAndUpdateList()
     -- FixedUpdate
     ModuleUtil.GetModuleListWithFunc(Module.S_Module, 'FixedUpdate', fixedUpdateList)
     -- Plugin
-    for _, m in pairs(FrameworkConfig.Server.PluginModules) do
-        ModuleUtil.GetModuleListWithFunc(m, 'InitDefault', initDefaultList)
-        ModuleUtil.GetModuleListWithFunc(m, 'Awake', awakeList)
-        ModuleUtil.GetModuleListWithFunc(m, 'Start', startList)
-        ModuleUtil.GetModuleListWithFunc(m, 'Update', updateList)
-        ModuleUtil.GetModuleListWithFunc(m, 'LateUpdate', lateUpdateList)
-        ModuleUtil.GetModuleListWithFunc(m, 'FixedUpdate', fixedUpdateList)
+    for _, m in pairs(PluginConfig) do
+        if not Plugin[m].S_Module then
+            return
+        end
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].S_Module, 'InitDefault', initDefaultList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].S_Module, 'Awake', awakeList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].S_Module, 'Start', startList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].S_Module, 'Update', updateList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].S_Module, 'LateUpdate', lateUpdateList)
+        ModuleUtil.GetModuleListWithFunc(Plugin[m].S_Module, 'FixedUpdate', fixedUpdateList)
     end
 end
 

--- a/Code/['World']['Global']['ModuleRequireScript'].Script.lua
+++ b/Code/['World']['Global']['ModuleRequireScript'].Script.lua
@@ -5,6 +5,9 @@
 -- Game Defines
 GAME_ID = 'X0000'
 print('GAME_ID = ', GAME_ID)
+PluginConfig = {
+	'FUNC_Guide'
+}
 
 -- Utilities
 ModuleUtil = require(Utility.ModuleUtilModule)
@@ -42,4 +45,6 @@ ModuleUtil.LoadModules(Module.Cls_Module)
 ModuleUtil.LoadModules(Module.C_Module)
 
 -- Plugin Modules
-GuideSystem = require(world.Global.Plugin.FUNC_Guide.GuideSystemModule)
+for _, v in pairs(PluginConfig) do
+    ModuleUtil.LoadPlugin(Plugin[v])
+end

--- a/Code/['World']['Global']['Utility']['ModuleUtilModule'].ModuleScript.lua
+++ b/Code/['World']['Global']['Utility']['ModuleUtilModule'].ModuleScript.lua
@@ -21,6 +21,27 @@ function ModuleUtil.LoadModules(_root, _scope)
     end
 end
 
+
+--- 加载插件模块目录
+-- @author Xinwu Zhang
+-- @param _root 插件文件夹节点
+-- @param _scope 载入后脚本的作用域
+function ModuleUtil.LoadPlugin(_root, _scope)
+    _scope = _scope or _G
+    assert(_root, '[ModuleUtil] Plugin Node does NOT exist!')
+    _scope[_root.Name] = {}
+    local tmp, name = _root:GetChildren()
+    for _, v in pairs(tmp) do
+        for _, j in pairs(v:GetChildren()) do
+            if j.ClassName == 'ModuleScriptObject' then
+                name = (j.Name):gsub('Module', '')
+                print('[ModuleUtil] Load Module: ', _root.Name, name)
+                _scope[_root.Name][name] = require(j)
+            end
+        end
+    end
+end
+
 --- 加载XLS表格目录
 -- @param _root 模块目录的节点
 -- @param _config 所有Excel生成Lua文件的所在table，不允许是_G


### PR DESCRIPTION
1.插件现在在ModuleRequire里面的PluginConfig配置,配置方式为插件的文件夹名字
2.插件根目录下与框架具有同样的结构,分别是Define,C_Module,S_Module,Cls_Module,Utility文件夹,插件模块放于这几个文件夹下,文件夹可以缺省
3.插件的事件在Define/EventsModule里面配置,与框架的EventsModule结构相同
4.插件的模块加载后会在_G[插件文件夹名]表里面,避免插件之间或与游戏存在模块命名冲突